### PR TITLE
Update healthcheck configurations and environment variables in Docker…

### DIFF
--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -58,11 +58,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB:-signbank_prod}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB:-signbank_prod}"]
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 10
+      start_period: 60s
     networks:
       - signbank
     volumes:
@@ -82,11 +82,11 @@ services:
       - typesense_prod_data:/data
     command: '--data-dir /data --api-key=${TYPESENSE_API_KEY} --enable-cors'
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8108/health"]
+      test: ["CMD-SHELL", "bash -c ':> /dev/tcp/127.0.0.1/8108' || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 10
+      start_period: 60s
 
   dufs:
     image: sigoden/dufs

--- a/docker-compose.dockploy.yaml
+++ b/docker-compose.dockploy.yaml
@@ -40,7 +40,7 @@ services:
       postgres:
         condition: service_healthy
       typesense:
-        condition: service_healthy
+        condition: service_started
 
   frontend:
     build:
@@ -59,15 +59,15 @@ services:
     image: postgres:16
     container_name: signbank-postgres
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_USER: ${POSTGRES_USER:-signbank}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB:-signbank}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB:-signbank}"]
+      test: ["CMD", "pg_isready", "-U", "signbank", "-d", "signbank"]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 10
+      start_period: 60s
     networks:
       - signbank
     volumes:
@@ -85,12 +85,6 @@ services:
     volumes:
       - typesense_data:/data
     command: '--data-dir /data --api-key=${TYPESENSE_API_KEY} --enable-cors'
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8108/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
     restart: unless-stopped
 
   dufs:

--- a/docker-compose.ghcr.yaml
+++ b/docker-compose.ghcr.yaml
@@ -41,7 +41,7 @@ services:
       postgres:
         condition: service_healthy
       typesense:
-        condition: service_healthy
+        condition: service_started
 
   frontend:
     image: ghcr.io/${GHCR_OWNER:-upf-gti}/${GHCR_REPO:-signbank}/frontend:${IMAGE_TAG:-main}
@@ -57,15 +57,15 @@ services:
     image: postgres:16
     container_name: signbank-postgres
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_USER: ${POSTGRES_USER:-signbank}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB:-signbank}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB:-signbank}"]
+      test: ["CMD", "pg_isready", "-U", "signbank", "-d", "signbank"]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 10
+      start_period: 60s
     networks:
       - signbank
     volumes:
@@ -83,12 +83,6 @@ services:
     volumes:
       - typesense_data:/data
     command: '--data-dir /data --api-key=${TYPESENSE_API_KEY} --enable-cors'
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8108/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
     restart: unless-stopped
 
   dufs:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -190,6 +190,30 @@ Set all env vars in the Dockploy project settings (never commit secrets).
 | Search empty after restart | Typesense bootstrap logs; admin `POST /api/typesense/sync` |
 | Videos 404 | `FileServer/` exists and dufs volume mounted |
 | Migration failed | `prisma migrate status`; see DATABASE.md |
+| Typesense / postgres unhealthy | See [Healthcheck failures](#healthcheck-failures) below |
+
+---
+
+## Healthcheck failures
+
+If deploy fails with `typesense is unhealthy` or `postgres failed to start`:
+
+1. **Required env vars in Dockploy** — confirm these are set (not empty):
+   - `POSTGRES_PASSWORD`
+   - `TYPESENSE_API_KEY` (any long random string; same value used by Typesense and backend)
+   - `JWT_SECRET` (32+ characters)
+
+2. **Typesense** — no Docker healthcheck (same as local dev). Backend starts after Typesense **container starts**, not after a health probe. The Typesense image has no `wget`, `curl`, or reliable shell for HTTP/TCP checks.
+
+3. **Postgres** — healthcheck uses `pg_isready -U signbank -d signbank`. Keep `POSTGRES_USER=signbank` and `POSTGRES_DB=signbank`, or update the healthcheck in compose to match.
+
+4. **Redeploy after compose changes** — in Dockploy, stop/remove the stack or redeploy so healthcheck config is recreated (Docker does not always update healthchecks on existing containers).
+
+5. **Inspect logs** (SSH on server):
+   ```bash
+   docker logs signbank-typesense
+   docker logs signbank-postgres
+   ```
 
 ---
 


### PR DESCRIPTION
… Compose files

This commit modifies the healthcheck commands for PostgreSQL and Typesense services across multiple Docker Compose files, enhancing reliability by increasing retries and start periods. Additionally, it updates the PostgreSQL user environment variable to a default value and changes the healthcheck condition for Typesense from 'service_healthy' to 'service_started'. Documentation for healthcheck failures is also added to provide guidance on troubleshooting.